### PR TITLE
[DEV-38913] duplicate pom tag causes runtime error

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -36,10 +36,6 @@ object build {
     licenses := Seq(("Apache-2.0", new URL("http://www.apache.org/licenses/LICENSE-2.0"))),
     pomExtra := {
       pomExtra.value ++ Group(
-      <scm>
-        <url>http://github.com/livongo/json4s</url>
-        <connection>scm:git:git://github.com/livongo/json4s.git</connection>
-      </scm>
       <developers>
         <developer>
           <id>casualjim</id>


### PR DESCRIPTION
Note that I chose not to increment the version number since this is strictly a publishing/artifact bug.   