### PR TITLE
artifactory.{prod,internal} migration

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature")
 
 resolvers += Resolver.url(
   "Artifactory ivy",
-  url("http://artifactory.prod.livongo.com/artifactory/plugins-release-local")
+  url("https://artifactory.internal.livongo.com/artifactory/plugins-release-local")
 )(Resolver.ivyStylePatterns)
 
 addSbtPlugin("livongo" %% "build-plugins" % "0.2.0")


### PR DESCRIPTION
Update artifactory.prod references to read from artifactory.internal instead. The repositories on artifactory.prod are being replicated over to artifactory.internal and readers should be able to find what they need there.